### PR TITLE
Fix xlint warning in final version of template

### DIFF
--- a/src/packaging/j4-dmenu-desktop.md
+++ b/src/packaging/j4-dmenu-desktop.md
@@ -1505,8 +1505,8 @@ Here is the **final** template:
 pkgname=j4-dmenu-desktop
 version=2.18
 revision=1
-configure_args="-DWITH_TESTS=NO"
 build_style=cmake
+configure_args="-DWITH_TESTS=NO"
 depends=dmenu
 short_desc="Fast desktop menu"
 maintainer="meator <meator.dev@gmail.com>"


### PR DESCRIPTION
The final version of the template for packaging j4-dmenu-desktop was still breaking the style recommended by xlint.  It had the `configure_args` before the `build_style`.
