### PR TITLE
Rename "dynamic" libraries to "shared" libraries

### DIFF
--- a/src/packaging/bat.md
+++ b/src/packaging/bat.md
@@ -176,9 +176,9 @@ _This is described in [Packaging oniguruma](oniguruma.md) in detail._
 To compile the `bat` package which depends on library `oniguruma`, `bat` must
 have `oniguruma-devel` in its `hostmakedepends`. But `oniguruma` must be
 installed alongside `bat` for `bat` to work because `oniguruma` provides
-dynamic libraries `bat` needs.
+shared libraries `bat` needs.
 
-When a program is linked against a dynamic library, the program "remembers"
+When a program is linked against a shared library, the program "remembers"
 which library it has been linked to. It marks the SONAME of the library in the
 executable. The details of this process are beyond the scope of this tutorial.
 

--- a/src/packaging/index.md
+++ b/src/packaging/index.md
@@ -19,7 +19,7 @@ for personal use.
   a fork, know how to make a pull request)
 - basics of CLI
 - knowledge of the build system of the packaged program is preferable
-- knowledge of libraries (what's a static/dynamic library, why are they
+- knowledge of libraries (what's a static/shared library, why are they
   important, what's a SONAME, etc.) is useful
 - knowing what a patch is, how to make one, and how to apply it is preferable
   (they are used in [packaging j4-dmenu-desktop](/packaging/j4-dmenu-desktop.md)

--- a/src/packaging/j4-dmenu-desktop.md
+++ b/src/packaging/j4-dmenu-desktop.md
@@ -51,13 +51,13 @@ there.
 
 If you are a more knowledgeable Linux user, you could set up a separate destdir
 for `j4-dmenu-desktop`. You will have to add it to `$PATH` and potentially handle
-dynamic libraries. This is cumbersome.
+shared libraries. This is cumbersome.
 
 Let's say that you were so amazed by `j4-dmenu-desktop` that you rushed to tell
 your friends and colleagues about it. They naturally want to try it out too. But
 the program could be big, it could take hours to build and its build system
 could be complicated and involved. All these problems are avoidable because
-your friends only need the executables (and dynamic libraries + possibly some
+your friends only need the executables (and shared libraries + possibly some
 supplementary data files like `/etc/` config). You already have all of this, you
 just need to send it to them. They don't need the code.
 

--- a/src/packaging/oniguruma.md
+++ b/src/packaging/oniguruma.md
@@ -49,11 +49,11 @@ This is useful to for example separate large documentation from a program.
 But this feature is used the most for `-devel` packages. All libraries usually
 provide (at least) two packages: the main package and a `-devel` package.
 
-The main package contains the core (dynamic) library. It is needed for programs
+The main package contains the core (shared) library. It is needed for programs
 which depend on this library.
 
 The `-devel` package contains development files needed to **compile** projects
-that depend on the library. It includes extra symbolic links to the dynamic
+that depend on the library. It includes extra symbolic links to the shared
 library, static libraries, pkg-config files, CMake files, header files and more.
 
 The `-devel` package should always depend on the main package. Installing the
@@ -269,7 +269,7 @@ oniguruma>=6.8.1_1
 It depends on `oniguruma>=6.8.1_1` even though the template doesn't even have a
 `depends` field. How is that possible?
 
-Each program remembers what dynamic libraries has it been linked with. It
+Each program remembers what shared libraries has it been linked with. It
 remembers the SONAME of the linked library.
 
 You can query the SONAMEs a library provides with `objdump`


### PR DESCRIPTION
This might be a bit of a controversial change, what do you think? On Unix the term "shared library" is more common, hence the `.so` file extension ("shared object") and the "SHLIB" abbreviation. Even the Wikipedia article uses the term [shared library](https://en.wikipedia.org/wiki/Shared_library). In my opinion using the term "shared" is more consistent with the rest of the Unix terminology.
